### PR TITLE
feat: 헤더 디자인 및 레이아웃 적용 

### DIFF
--- a/src/layout/FullContainer.tsx
+++ b/src/layout/FullContainer.tsx
@@ -1,0 +1,11 @@
+import {Outlet} from "react-router-dom";
+
+const FullContainer = () => {
+    return(
+        <div className="container">
+            <Outlet />
+        </div>
+    )
+}
+
+export default FullContainer;

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -1,3 +1,5 @@
+import uwellnowlogo from '../../public/uwellnow.svg'
+
 const Header = () => {
     const today = new Date().toLocaleDateString('ko-KR', {
         year: 'numeric',
@@ -8,10 +10,17 @@ const Header = () => {
     return(
         <div className="flex items-center flex-shrink-0 h-[100px] bg-white w-full justify-between ">
             <div className="px-8 text-grayBlue font-semibold text-2xl" >{today}</div>
-            <div className="px-10 flex flex-col space-y-1" >
-                <div className="text-black font-bold text-md">유웰나우 관리자</div>
-                <div className="text-gray-600 font-medium text-sm">로그아웃</div>
+            <div className="px-10 flex space-x-4">
+                <div className="rounded-full overflow-hidden size-12">
+                    <img src={uwellnowlogo}/>
+                </div>
+
+                <div className="flex flex-col space-y-1" >
+                    <div className="text-black font-bold text-md">유웰나우 관리자</div>
+                    <div className="text-gray-600 font-medium text-sm">로그아웃</div>
+                </div>
             </div>
+
 
         </div>
     )

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -1,5 +1,20 @@
 const Header = () => {
+    const today = new Date().toLocaleDateString('ko-KR', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+    });
 
+    return(
+        <div className="flex items-center flex-shrink-0 h-[100px] bg-white w-full justify-between ">
+            <div className="px-8 text-grayBlue font-semibold text-2xl" >{today}</div>
+            <div className="px-10 flex flex-col space-y-1" >
+                <div className="text-black font-bold text-md">유웰나우 관리자</div>
+                <div className="text-gray-600 font-medium text-sm">로그아웃</div>
+            </div>
+
+        </div>
+    )
 }
 
 export default Header;

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,14 +1,21 @@
 import Sidebar from "./Sidebar.tsx";
-import {Outlet} from "react-router-dom";
+import Header from "./Header.tsx";
+import FullContainer from "./FullContainer.tsx";
 
 const MainLayout = () => {
     return (
-        <div className="flex min-h-screen">
+        <div className="flex flex-row min-h-screen">
             <Sidebar />
+            <div className="flex flex-col flex-1">
+                <Header />
 
-            <main className="flex-1 p-6">
-                <Outlet />
-            </main>
+                <main className="flex-1 p-6">
+                    <FullContainer />
+                </main>
+            </div>
+
+
+
         </div>
     )
 }

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -17,7 +17,7 @@ const sideItems = [
 const Sidebar = () => {
 
     return (
-        <aside className="w-[345px] bg-white min-h-screen border-none border-gray-200">
+        <aside className="w-80 min-h-screen bg-white border-none border-gray-200">
             <div className="p-6 flex items-center justify-center space-x-4">
                 <img src={uwellnowlogo} alt="uwellnow logo" className="w-8 h-8" />
                 <span className="text-2xl font-semibold">uwellnow admin</span>

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -31,7 +31,7 @@ const Sidebar = () => {
                         className={({ isActive }) =>
                             `flex items-center px-6 py-3 h-16 rounded-2xl text-md transition ${
                                 isActive
-                                    ? 'bg-mainRed text-white font-bold hover:text-white'
+                                    ? 'bg-mainRed text-white font-bold text-lg hover:text-white'
                                     : 'text-lightGray font-medium hover:text-lightGray'
                             }`
                         }
@@ -60,7 +60,7 @@ const Sidebar = () => {
 
 
             <div className="mt-auto px-4 absolute bottom-6">
-                <button className="flex items-center w-full px-4 py-3 text-md font-medium text-gray-600 rounded-lg">
+                <button className="flex items-center w-full px-4 py-3 text-md font-medium text-lightGray rounded-lg">
                     <img src={signout} alt="로그아웃" className="mr-3" />
                     로그아웃
                 </button>

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -2,5 +2,6 @@ export const UWELL_COLOR = {
     midGray: '#ECECEC',
     mainRed: '#C50019',
     textGray: '#979797',
-    lightGray: '#737791'
+    lightGray: '#737791',
+    grayBlue: '#151D48'
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,7 @@ export default {
         mainRed: UWELL_COLOR.mainRed,
         textGray: UWELL_COLOR.textGray,
         lightGray: UWELL_COLOR.lightGray,
+        grayBlue: UWELL_COLOR.grayBlue,
       }
     },
     fontFamily: {


### PR DESCRIPTION
### 목적
- 헤더 디자인 구현 및 레이아웃 적용
- 관리자 프로필 사진은 일단 유웰나우 로고
- 사이드바 메뉴 선택 시 텍스트 확대 되도록 

### 화면 이미지
<img width="1274" height="672" alt="{E77DA1FB-815A-49E7-B626-41EB13DD0D1E}" src="https://github.com/user-attachments/assets/8fce3378-8ad5-4274-9587-c1e7c6e40b1e" />
